### PR TITLE
Implement WheelResolutionMultiplier and PanResolutionMultiplier as Byte between 0 and 3 instead of Boolean

### DIFF
--- a/app/src/main/java/com/github/roarappstudio/btkontroller/BluetoothController.kt
+++ b/app/src/main/java/com/github/roarappstudio/btkontroller/BluetoothController.kt
@@ -28,8 +28,8 @@ object BluetoothController: BluetoothHidDevice.Callback(), BluetoothProfile.Serv
 
         Log.i("get", "second")
             if (type == BluetoothHidDevice.REPORT_TYPE_FEATURE) {
-                featureReport.wheelResolutionMultiplier = true
-                featureReport.acPanResolutionMultiplier = true
+                featureReport.wheelResolutionMultiplier = 3
+                featureReport.acPanResolutionMultiplier = 1
                 Log.i("getbthid","$btHid")
 
                  var wasrs=btHid?.replyReport(device, type, FeatureReport.ID, featureReport.bytes)

--- a/app/src/main/java/com/github/roarappstudio/btkontroller/reports/FeatureReport.kt
+++ b/app/src/main/java/com/github/roarappstudio/btkontroller/reports/FeatureReport.kt
@@ -1,5 +1,6 @@
 package com.github.roarappstudio.btkontroller.reports
 
+import java.lang.IllegalArgumentException
 import kotlin.experimental.and
 import kotlin.experimental.or
 
@@ -8,23 +9,40 @@ inline class FeatureReport (
     val bytes: ByteArray = ByteArray(1) {0}
 ) {
 
-
-    var wheelResolutionMultiplier: Boolean
-        get() = bytes[0] and 0b1 != 0.toByte()
+    /**
+     * Bits 0 and 1 of Feature Report
+     */
+    var wheelResolutionMultiplier: Byte
+        get() = bytes[0] and 0b00000011
         set(value) {
-            bytes[0] = if (value)
-                bytes[0] or 0b1
-            else
-                bytes[0] and 0b1110
+            if (value > 3)
+                throw IllegalArgumentException("WheelResolutionMultiplier must be between 0 and 3.")
+
+            // reset WheelResolutionBits to 0
+            bytes[0] = bytes[0] and 0b11111100.toByte()
+            // set value to WheelResolutionBits
+            bytes[0] = bytes[0] or value
         }
 
-    var acPanResolutionMultiplier: Boolean
-        get() = bytes[0] and 0b100 != 0.toByte()
+    /**
+     * Bits 2 and 3 of Featue Report
+     */
+    var acPanResolutionMultiplier: Byte
+        get() {
+            val panBits = bytes[0] and 0b00001100
+            return (panBits.toInt() shr 2).toByte()
+        }
         set(value) {
-            bytes[0] = if (value)
-                bytes[0] or 0b100
-            else
-                bytes[0] and 0b1011
+            if (value > 3)
+                throw IllegalArgumentException("PanResolutionMultiplier must be between 0 and 3.")
+
+            // shift value to the right bits
+            val panBits = (value.toInt() shl 2).toByte()
+
+            // reset PanResolutionBits to 0
+            bytes[0] = bytes[0] and 0b11110011.toByte()
+            // set value to PanResolutionBits
+            bytes[0] = bytes[0] or panBits
         }
 
 


### PR DESCRIPTION
It's really subjective and my feelings might be wrong, but this could be a fix to #1. Maybe you want to try?

Future work could be to implement a Slider somewhere in the UI, where the multiplier values could be set by the user, but for me these hard coded values are ok.